### PR TITLE
Update __main__.py

### DIFF
--- a/src/mvextractor/__main__.py
+++ b/src/mvextractor/__main__.py
@@ -13,10 +13,12 @@ from mvextractor.videocap import VideoCap
 def draw_motion_vectors(frame, motion_vectors):
     if len(motion_vectors) > 0:
         num_mvs = np.shape(motion_vectors)[0]
+        shift = 2
+        factor = (1 << shift)
         for mv in np.split(motion_vectors, num_mvs):
-            start_pt = (mv[0, 3], mv[0, 4])
-            end_pt = (mv[0, 5], mv[0, 6])
-            cv2.arrowedLine(frame, start_pt, end_pt, (0, 0, 255), 1, cv2.LINE_AA, 0, 0.1)
+            start_pt = (int((mv[0, 5] + mv[0, 7] / mv[0, 9]) * factor + 0.5), int((mv[0, 6] + mv[0, 8] / mv[0, 9]) * factor + 0.5))
+            end_pt = (mv[0, 5] * factor, mv[0, 6] * factor)
+            cv2.arrowedLine(frame, start_pt, end_pt, (0, 0, 255), 1, cv2.LINE_AA, shift, 0.1)
     return frame
 
 


### PR DESCRIPTION
extract motion vectors at h264 quarter-pixel precision

Currently the code uses only the integer precision end-point of motion vectors. However, AVMotionVector contains motion_x, motion_y and motion_scale values which allow for sub-pixel motion vector lengths.

This should be hardly visible in the visualization, but will show how to get more accurate motion vectors.