### PR TITLE
Limit the maximal number of threads used by FFmpeg to 16.

### DIFF
--- a/src/mvextractor/video_cap.cpp
+++ b/src/mvextractor/video_cap.cpp
@@ -112,7 +112,9 @@ bool VideoCap::open(const char *url) {
     if (avcodec_parameters_to_context(this->video_dec_ctx, st->codecpar) < 0)
         goto error;
 
-    this->video_dec_ctx->thread_count = std::thread::hardware_concurrency();
+    // FFmpeg recommends no more than 16 threads
+    auto thread_count = std::min(std::thread::hardware_concurrency(), 16u);
+    this->video_dec_ctx->thread_count = static_cast<int>(thread_count);
 #ifdef DEBUG
     std::cerr << "Using parallel processing with " << this->video_dec_ctx->thread_count << " threads" << std::endl;
 #endif


### PR DESCRIPTION
This solves issue #32 by limiting the number of threads to no more than 16.