### PR TITLE
upgrade Docker image to manylinux_2_28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,27 @@
-FROM quay.io/pypa/manylinux_2_24_x86_64 AS builder
+FROM quay.io/pypa/manylinux_2_28_x86_64 AS builder
 
 WORKDIR /home/video_cap
 
 # Install build tools
-RUN apt-get update -qq --fix-missing && \
-  apt-get upgrade -y && \
-  apt-get install -y \
+RUN yum update -y && \
+  yum install -y \
     wget \
     unzip \
-    build-essential \
+    make \
+    gcc \
+    gcc-c++ \
     cmake \
     git \
-    pkg-config \
+    pkgconfig \
     autoconf \
     automake \
-    git-core && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install OpenCV
-COPY install_opencv.sh /home/video_cap
-RUN mkdir -p /home/video_cap && \
-  cd /home/video_cap && \
-  chmod +x install_opencv.sh && \
-  ./install_opencv.sh
+    git-core \
+    bzip2 \
+    bzip2-devel \
+    freetype-devel \
+    libtool \
+    zlib-devel && \
+  yum clean all
 
 # Install FFMPEG
 COPY install_ffmpeg.sh /home/video_cap
@@ -32,30 +31,32 @@ RUN mkdir -p /home/video_cap && \
   chmod +x install_ffmpeg.sh && \
   ./install_ffmpeg.sh
 
-FROM quay.io/pypa/manylinux_2_24_x86_64
+# Install OpenCV
+COPY install_opencv.sh /home/video_cap
+RUN mkdir -p /home/video_cap && \
+  cd /home/video_cap && \
+  chmod +x install_opencv.sh && \
+  ./install_opencv.sh
 
-RUN apt-get update && \
-  apt-get -y install \
-    pkg-config \
-    libgtk-3-dev \
-    libavcodec-dev \
-    libavformat-dev \
-    libswscale-dev \
-    libmp3lame-dev \
-    zlib1g-dev \
-    libx264-dev \
-    libsdl2-dev \
-    libvpx-dev \
-    libvdpau-dev \
-    libvorbis-dev \
-    libopus-dev \
-    libdc1394-22-dev \
-    liblzma-dev && \
-    rm -rf /var/lib/apt/lists/*
+FROM quay.io/pypa/manylinux_2_28_x86_64
+
+RUN yum update -y && \
+  yum install -y \
+    pkgconfig \
+    gtk3-devel \
+    zlib-devel \
+    SDL2-devel \
+    libvpx-devel \
+    libvorbis-devel \
+    opus-devel \
+    xz-devel && \
+  yum clean all
 
 # copy libraries
 WORKDIR /usr/local/lib
 COPY --from=builder /usr/local/lib .
+WORKDIR /usr/local/lib64
+COPY --from=builder /usr/local/lib64 .
 WORKDIR /usr/local/include
 COPY --from=builder /home/ffmpeg_build/include .
 WORKDIR /home/ffmpeg_build/lib
@@ -67,7 +68,7 @@ COPY --from=builder /home/opencv/build/lib .
 
 # Set environment variables
 ENV PATH="$PATH:/home/bin"
-ENV PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/home/ffmpeg_build/lib/pkgconfig"
+ENV PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/home/ffmpeg_build/lib/pkgconfig:/usr/local/lib64/pkgconfig"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/opencv/build/lib"
 
 WORKDIR /home/video_cap
@@ -77,11 +78,11 @@ COPY src /home/video_cap/src/
 
 # Install Python package
 RUN python3.10 -m pip install --upgrade pip build && \
-  python3.10 -m pip install 'pkgconfig>=1.5.1' 'numpy>=1.17.0'
+  python3.10 -m pip install 'pkgconfig>=1.5.1' 'numpy>=1.17.0,<2'
 
 RUN python3.10 -m pip install .
 
 # that is where the "extract_mvs" script is located
-ENV PATH="$PATH:/opt/_internal/cpython-3.10.2/bin"
+ENV PATH="$PATH:/opt/_internal/cpython-3.10.15/bin"
 
 CMD ["sh", "-c", "tail -f /dev/null"]

--- a/install_ffmpeg.sh
+++ b/install_ffmpeg.sh
@@ -5,74 +5,76 @@ INSTALL_DIR="$PWD"
 
 echo "Installing FFMPEG into: $INSTALL_DIR"
 
-# Install FFMPEG dependencies
-echo "Installing FFMPEG dependencies"
-apt-get update -qq --fix-missing && \
-apt-get upgrade -y && \
-apt-get -y install \
-    libass-dev \
-    libfreetype6-dev \
-    libsdl2-dev \
-    libtool \
-    libva-dev \
-    libvdpau-dev \
-    libvorbis-dev \
-    libxcb1-dev \
-    libxcb-shm0-dev \
-    libxcb-xfixes0-dev \
-    texinfo \
-    zlib1g-dev \
-    nasm \
-    yasm \
-    libx264-dev \
-    libx265-dev \
-    libnuma-dev \
-    libvpx-dev \
-    libmp3lame-dev \
-    libopus-dev
+mkdir -p "$INSTALL_BASE_DIR/bin"
+mkdir -p "$INSTALL_BASE_DIR/ffmpeg_sources"
+mkdir -p "$INSTALL_BASE_DIR/ffmpeg_build"
+PATH="$PATH:$INSTALL_BASE_DIR/bin"
 
+# Build and install NASM
+echo "Building and installing NASM"
+cd "$INSTALL_BASE_DIR/ffmpeg_sources"
+curl -O -L https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.bz2
+tar xjvf nasm-2.15.05.tar.bz2
+cd nasm-2.15.05
+./autogen.sh
+./configure --prefix="$INSTALL_BASE_DIR/ffmpeg_build" --bindir="$INSTALL_BASE_DIR/bin"
+make -j $(nproc)
+make install
+
+# Build and install Yasm
+echo "Building and installing Yasm"
+cd "$INSTALL_BASE_DIR/ffmpeg_sources"
+curl -O -L https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
+tar xzvf yasm-1.3.0.tar.gz
+cd yasm-1.3.0
+./configure --prefix="$INSTALL_BASE_DIR/ffmpeg_build" --bindir="$INSTALL_BASE_DIR/bin"
+make -j $(nproc)
+make install
+
+# Build and install libx264
+echo "Building and installing libx264"
+cd "$INSTALL_BASE_DIR/ffmpeg_sources"
+git clone --branch stable --depth 1 https://code.videolan.org/videolan/x264.git
+cd x264
+PKG_CONFIG_PATH="$INSTALL_BASE_DIR/ffmpeg_build/lib/pkgconfig" ./configure --prefix="$INSTALL_BASE_DIR/ffmpeg_build" --bindir="$INSTALL_BASE_DIR/bin" --enable-static --enable-pic
+make -j $(nproc)
+make install
 
 # Download FFMPEG source
 FFMPEG_VERSION="4.1.3"
 echo "Downloading FFMPEG source"
-mkdir -p "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg "$INSTALL_BASE_DIR"/bin
+mkdir -p "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg
 cd "$INSTALL_BASE_DIR"/ffmpeg_sources
 wget -O ffmpeg-snapshot.tar.bz2 https://ffmpeg.org/releases/ffmpeg-"$FFMPEG_VERSION".tar.bz2
 tar xjvf ffmpeg-snapshot.tar.bz2 -C "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg --strip-components=1
 rm -rf "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg-snapshot.tar.bz2
 cd "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg
 
-
 # Install patch for FFMPEG which exposes timestamp in AVPacket
 echo "Patching FFMPEG"
 export FFMPEG_INSTALL_DIR="$INSTALL_BASE_DIR/ffmpeg_sources/ffmpeg"
 export FFMPEG_PATCH_DIR="$INSTALL_DIR/ffmpeg_patch"
-
 chmod +x "$FFMPEG_PATCH_DIR"/patch.sh
 "$FFMPEG_PATCH_DIR"/patch.sh
 
-
 # Compile FFMPEG
 echo "Configuring FFMPEG"
-cd "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg && \
-./configure \
+cd "$INSTALL_BASE_DIR"/ffmpeg_sources/ffmpeg
+PATH="$INSTALL_BASE_DIR/bin:$PATH" PKG_CONFIG_PATH="$INSTALL_BASE_DIR/ffmpeg_build/lib/pkgconfig" ./configure \
 --prefix="$INSTALL_BASE_DIR/ffmpeg_build" \
 --pkg-config-flags="--static" \
---extra-cflags="-I$INSTALL_BASE_DIR/ffmpeg_build/include -static" \
---extra-ldflags="-L$INSTALL_BASE_DIR/ffmpeg_build/lib -static" \
---extra-libs="-lpthread -lm" \
+--extra-cflags="-I$INSTALL_BASE_DIR/ffmpeg_build/include" \
+--extra-ldflags="-L$INSTALL_BASE_DIR/ffmpeg_build/lib" \
+--extra-libs=-lpthread \
+--extra-libs=-lm \
 --bindir="$INSTALL_BASE_DIR/bin" \
 --enable-gpl \
 --enable-libfreetype \
---enable-libmp3lame \
---enable-libopus \
---enable-libvorbis \
---enable-libvpx \
 --enable-libx264 \
 --enable-nonfree \
 --enable-pic
 
 echo "Compiling FFMPEG"
-make -j $(nproc) && \
-make install && \
+make -j $(nproc)
+make install
 hash -r

--- a/install_opencv.sh
+++ b/install_opencv.sh
@@ -7,29 +7,18 @@ echo "Installing OpenCV into: $INSTALL_DIR"
 
 # Install opencv dependencies
 echo "Installing OpenCV dependencies"
-apt-get update -qq --fix-missing && \
-apt-get upgrade -y && \
-apt-get install -y \
-    libgtk-3-dev \
-    libavcodec-dev \
-    libavformat-dev \
-    libswscale-dev \
-    libv4l-dev \
-    libxvidcore-dev \
-    libx264-dev \
-    libx265-dev \
-    libjpeg-dev \
-    libpng-dev \
-    libtiff-dev \
-    libatlas-base-dev \
-    gfortran \
-    openexr \
-    libtbb2 \
-    libtbb-dev \
-    libdc1394-22-dev \
-    libgtk2.0-dev && \
-    rm -rf /var/lib/apt/lists/*
-
+yum update -y && \
+yum install -y \
+    gtk3-devel \
+    libjpeg-turbo-devel \
+    libpng-devel \
+    libtiff-devel \
+    libv4l-devel \
+    gcc-gfortran \
+    openexr-devel \
+    tbb-devel \
+    gtk2-devel && \
+    yum clean all
 
 # Download OpenCV and build from source
 OPENCV_VERSION="4.5.5"

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,4 @@ setup(name='motion-vector-extractor',
               ],
        },
        python_requires='>=3.8, <4',
-       install_requires=['pkgconfig>=1.5.1', 'numpy>=1.17.0', 'opencv-python>=4.1.0.25,<4.6'])
+       install_requires=['pkgconfig>=1.5.1', 'numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.6'])


### PR DESCRIPTION
Upgrades the docker image from manylinux_2_24 to manylinux_2_28 as manylinux_2_24 reached its end of life 1st Jan 2023 (see [here](https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_24-debian-9-based---eol)).

manylinux_2_24 was based on Debian 9, whereas manylinux_2_28 is based on Alma Linux 8 (RHEL-compatile). System packages are now installed with yum instead of apt-get and names of packages changed.