### PR TITLE
Split workflow into CI and release parts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,8 @@
 # - builds the Docker image,
 # - build wheels for different Python versions,
 # - installs the wheel for each Python version and runs the unit tests.
-# On manual dispatch this workflow:
-# - pushes the previously built Docker image to DockerHub with tag "dev".
 
-name: ci and release
+name: ci
 
 on:
   push:
@@ -71,46 +69,6 @@ jobs:
           docker run -v ${{ github.workspace }}:/home/video_cap \
             mv-extractor:local \
               python3.10 tests/tests.py
-
-  # # TODO: run tests on other operating systems than ubuntu-latest
-  # run_unit_tests:
-  #   name: Run unit tests for python${{ matrix.python }}
-  #   runs-on: ubuntu-latest
-  #   needs: build_docker
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #       - python: "3.9"
-  #       - python: "3.10"
-  #       - python: "3.11"
-  #       - python: "3.12"
-  #       - python: "3.13"
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-
-  #     - name: Download artifact containing Docker image
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: mv-extractor-docker-image
-  #         path: /tmp
-      
-  #     - name: Load Docker image
-  #       run: |
-  #         docker load --input /tmp/image.tar
-
-  #     - name: Run unit tests for all supported Python versions
-  #       run: |
-  #         docker run \
-  #           -v ${{ github.workspace }}:/home/video_cap \
-  #           mv-extractor:local \
-  #             /bin/bash -c "
-  #               python${{ matrix.python }} -m pip install --upgrade pip && \
-  #               python${{ matrix.python }} -m pip install . && \
-  #               python${{ matrix.python }} tests/tests.py
-  #             "
 
   build_and_test_wheels:
     name: Build wheels for cp${{ matrix.python }}-${{ matrix.platform_id }}
@@ -180,35 +138,3 @@ jobs:
         with:
           name: python-wheel-${{ matrix.python }}
           path: ./wheelhouse/*.whl
-  
-  # TODO:
-  # check that tag does not yet exist on DockerHub and PyPI, fail with a message that version has to be bumped in setup.py
-  # tag image with correct version and "latest" tag
-  # upload wheels to PyPI
-  push_docker:
-    name: Push Docker image to DockerHub
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    needs: 
-      - build_docker
-      - test_docker
-      - build_and_test_wheels
-
-    steps:
-      - name: Download artifact containing Docker image
-        uses: actions/download-artifact@v4
-        with:
-          name: mv-extractor-docker-image
-          path: /tmp
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Load and push Docker image
-        run: |
-          docker load --input /tmp/image.tar
-          docker tag mv-extractor:local lubo1994/mv-extractor:dev
-          docker push lubo1994/mv-extractor:dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # TODO:
+  # check that tag does not yet exist on DockerHub and PyPI, fail with a message that version has to be bumped in setup.py
+  # tag image with correct version and "latest" tag
+  # upload wheels to PyPI
+  push_docker:
+    name: Push Docker image to DockerHub
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifact containing Docker image
+        uses: actions/download-artifact@v4
+        with:
+          name: mv-extractor-docker-image
+          path: /tmp
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Load and push Docker image
+        run: |
+          docker load --input /tmp/image.tar
+          docker tag mv-extractor:local lubo1994/mv-extractor:dev
+          docker push lubo1994/mv-extractor:dev


### PR DESCRIPTION
This PR splits the workflow into a CI part for building and testing artefacts (Docker image and Python wheels) and a release part for automating the creation of a release.