### PR TITLE
Upgrade OpenCV from 4.5.5 to 4.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,16 +73,14 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/home/opencv/build/lib"
 
 WORKDIR /home/video_cap
 
+COPY pyproject.toml /home/video_cap
 COPY setup.py /home/video_cap
 COPY src /home/video_cap/src/
 
 # Install Python package
-RUN python3.10 -m pip install --upgrade pip build && \
-  python3.10 -m pip install 'pkgconfig>=1.5.1' 'numpy>=1.17.0,<2'
-
 RUN python3.10 -m pip install .
 
-# that is where the "extract_mvs" script is located
+# Location of the "extract_mvs" script
 ENV PATH="$PATH:/opt/_internal/cpython-3.10.15/bin"
 
 CMD ["sh", "-c", "tail -f /dev/null"]

--- a/install_opencv.sh
+++ b/install_opencv.sh
@@ -21,7 +21,7 @@ yum install -y \
     yum clean all
 
 # Download OpenCV and build from source
-OPENCV_VERSION="4.5.5"
+OPENCV_VERSION="4.10.0"
 echo "Downloading OpenCV source"
 cd "$INSTALL_BASE_DIR"
 wget -O "$INSTALL_BASE_DIR"/opencv.zip https://github.com/opencv/opencv/archive/"$OPENCV_VERSION".zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools",
-    "pkgconfig",
-    "numpy"
+    "setuptools>=61.0",
+    "pkgconfig>=1.5.1",
+    "numpy>=1.17.0,<2"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,4 @@ setup(name='motion-vector-extractor',
             ],
     },
     python_requires='>=3.9, <4',
-    install_requires=['numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.6'])
+    install_requires=['numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.11'])

--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,4 @@ setup(name='motion-vector-extractor',
             ],
     },
     python_requires='>=3.9, <4',
-    install_requires=['pkgconfig>=1.5.1', 'numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.6'])
+    install_requires=['numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.6'])


### PR DESCRIPTION
This PR:
- upgrades OpenCV from 4.5.5 to 4.10.0
- fixes the installation of build and runtime dependencies
    - utilize `pyproject.toml` which was previously unused because it was not copied properly into the Dockerfile
    - get rid of pkgconfig as runtime dependency of the pip package

Closes https://github.com/LukasBommes/mv-extractor/issues/45 and https://github.com/LukasBommes/mv-extractor/issues/36