### PR TITLE
added assert to test_timings unit test case

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -148,7 +148,11 @@ class TestMotionVectorExtraction(unittest.TestCase):
             tend = time.perf_counter()
             telapsed = tend - tstart
             times.append(telapsed)
-        print(f"Timings: mean {np.mean(times)} -- std: {np.std(times)}")
+        dt_mean = np.mean(times)
+        dt_std = np.std(times)
+        print(f"Timings: mean {dt_mean} s -- std: {dt_std} s")
+        assert 0 < dt_mean < 0.01, f"Mean of frame read operation exceeds maximum ({dt_mean} s > {0.01} s)"
+        assert 0 < dt_std < 0.001, f"Standard deviation of frame read operation exceeds maximum ({dt_mean} s > {0.01} s)"
 
 
 


### PR DESCRIPTION
This PR adds assert statements to the unit test which measures mean and std of the `VideoCap.read` method. The asserts check if the values are within a meaningful range to capture scenarios in which the execution time drastically changes.

I am aware that unit testing for performance may not be the best idea. But I still think that in this case it's a good way to capture potential bugs.