### PR TITLE
Add support for numpy 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 # On a push to any branch this workflow:
 # - builds the Docker image,
 # - build wheels for different Python versions,
-# - installs the wheel for each Python version and runs the unit tests.
+# - installs the wheel for each Python version and runs the unit tests
+#   against newest and oldest versions of dependencies.
 # On manual dispatch this workflow:
 # - pushes the previously built Docker image to DockerHub with tag "dev".
 
@@ -158,61 +159,6 @@ jobs:
           name: python-wheel-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
-  # test_wheel_against_oldest_dependencies:
-  #   name: Test wheels against oldest supported versions of dependencies
-  #   runs-on: ${{ matrix.os }}
-  #   container: ${{ matrix.image }}
-  #   needs:
-  #     - build_docker
-  #     - build_and_test_wheels
-  #   strategy:
-  #     # Ensure that a wheel builder finishes even if another fails
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #       - os: ubuntu-latest
-  #         image: python:3.9
-  #         numpy_min_version: "numpy==1.19.3"
-  #         opencv_min_version: "opencv==4.4.0.46"
-  #       - os: ubuntu-latest
-  #         image: python:3.9
-  #         numpy_min_version: "numpy==1.21.2"
-  #         opencv_min_version: "opencv==4.5.4.60"
-  #       # - os: ubuntu-latest
-  #       #   python: "3.11"
-  #       #   numpy_min_version: 
-  #       #   opencv_min_version: 
-  #       # - os: ubuntu-latest
-  #       #   python: "3.12"
-  #       #   numpy_min_version: 
-  #       #   opencv_min_version: 
-  #       # - os: ubuntu-latest
-  #       #   python: "3.13"
-  #       #   numpy_min_version: 
-  #       #   opencv_min_version: 
-
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-
-  #     - name: Download wheels
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: python-wheel-${{ matrix.python }}
-  #         path: /tmp
-
-  #     - name: Install wheel
-  #       run: |
-  #         python3 -m pip install /tmp/*.whl
-
-  #     - name: Install oldest versions of dependencies
-  #       run: |
-  #         python3 -m pip install ${{ matrix.numpy_min_version }} ${{ matrix.opencv_min_version }}
-
-  #     - name: Run unit tests
-  #       run: |
-  #         python3 -m unittest discover -s tests -p "*tests.py"
-  
   push_docker:
     name: Push Docker image to DockerHub
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,26 +88,30 @@ jobs:
           bitness: 64
           platform_id: manylinux_x86_64
           manylinux_image: mv-extractor:local
+          numpy_min_version: "numpy==1.19.3"
+          opencv_min_version: "opencv==4.4.0.46"
         - os: ubuntu-latest
           python: 310
           bitness: 64
           platform_id: manylinux_x86_64
           manylinux_image: mv-extractor:local
-        - os: ubuntu-latest
-          python: 311
-          bitness: 64
-          platform_id: manylinux_x86_64
-          manylinux_image: mv-extractor:local
-        - os: ubuntu-latest
-          python: 312
-          bitness: 64
-          platform_id: manylinux_x86_64
-          manylinux_image: mv-extractor:local
-        - os: ubuntu-latest
-          python: 313
-          bitness: 64
-          platform_id: manylinux_x86_64
-          manylinux_image: mv-extractor:local
+          numpy_min_version: "numpy==1.21.2"
+          opencv_min_version: "opencv==4.5.4.60"
+        # - os: ubuntu-latest
+        #   python: 311
+        #   bitness: 64
+        #   platform_id: manylinux_x86_64
+        #   manylinux_image: mv-extractor:local
+        # - os: ubuntu-latest
+        #   python: 312
+        #   bitness: 64
+        #   platform_id: manylinux_x86_64
+        #   manylinux_image: mv-extractor:local
+        # - os: ubuntu-latest
+        #   python: 313
+        #   bitness: 64
+        #   platform_id: manylinux_x86_64
+        #   manylinux_image: mv-extractor:local
 
     steps:
       - name: Checkout
@@ -134,7 +138,12 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.manylinux_image }}
           #CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.manylinux_image }}
           CIBW_BUILD_FRONTEND: build
-          CIBW_TEST_COMMAND: PROJECT_ROOT={project} python3 -m unittest discover -s {project}/tests -p "*tests.py"
+          CIBW_TEST_COMMAND: |
+            echo "Running unit tests" && \
+            PROJECT_ROOT={project} python3 -m unittest discover -s {project}/tests -p "*tests.py" && \
+            echo "Running unit tests against oldest supported versions of dependencies" && \
+            python3 -m pip install ${{ matrix.numpy_min_version }} ${{ matrix.opencv_min_version }} && \
+            PROJECT_ROOT={project} python3 -m unittest discover -s {project}/tests -p "*tests.py"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4
@@ -142,60 +151,60 @@ jobs:
           name: python-wheel-${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
-  test_wheel_against_oldest_dependencies:
-    name: Test wheels against oldest supported versions of dependencies
-    runs-on: ${{ matrix.os }}
-    container: ${{ matrix.image }}
-    needs:
-      - build_docker
-      - build_and_test_wheels
-    strategy:
-      # Ensure that a wheel builder finishes even if another fails
-      fail-fast: false
-      matrix:
-        include:
-        - os: ubuntu-latest
-          image: python:3.9
-          numpy_min_version: "numpy==1.19.3"
-          opencv_min_version: "opencv==4.4.0.46"
-        - os: ubuntu-latest
-          image: python:3.9
-          numpy_min_version: "numpy==1.21.2"
-          opencv_min_version: "opencv==4.5.4.60"
-        # - os: ubuntu-latest
-        #   python: "3.11"
-        #   numpy_min_version: 
-        #   opencv_min_version: 
-        # - os: ubuntu-latest
-        #   python: "3.12"
-        #   numpy_min_version: 
-        #   opencv_min_version: 
-        # - os: ubuntu-latest
-        #   python: "3.13"
-        #   numpy_min_version: 
-        #   opencv_min_version: 
+  # test_wheel_against_oldest_dependencies:
+  #   name: Test wheels against oldest supported versions of dependencies
+  #   runs-on: ${{ matrix.os }}
+  #   container: ${{ matrix.image }}
+  #   needs:
+  #     - build_docker
+  #     - build_and_test_wheels
+  #   strategy:
+  #     # Ensure that a wheel builder finishes even if another fails
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #       - os: ubuntu-latest
+  #         image: python:3.9
+  #         numpy_min_version: "numpy==1.19.3"
+  #         opencv_min_version: "opencv==4.4.0.46"
+  #       - os: ubuntu-latest
+  #         image: python:3.9
+  #         numpy_min_version: "numpy==1.21.2"
+  #         opencv_min_version: "opencv==4.5.4.60"
+  #       # - os: ubuntu-latest
+  #       #   python: "3.11"
+  #       #   numpy_min_version: 
+  #       #   opencv_min_version: 
+  #       # - os: ubuntu-latest
+  #       #   python: "3.12"
+  #       #   numpy_min_version: 
+  #       #   opencv_min_version: 
+  #       # - os: ubuntu-latest
+  #       #   python: "3.13"
+  #       #   numpy_min_version: 
+  #       #   opencv_min_version: 
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Download wheels
-        uses: actions/download-artifact@v4
-        with:
-          name: python-wheel-${{ matrix.python }}
-          path: /tmp
+  #     - name: Download wheels
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: python-wheel-${{ matrix.python }}
+  #         path: /tmp
 
-      - name: Install wheel
-        run: |
-          python3 -m pip install /tmp/*.whl
+  #     - name: Install wheel
+  #       run: |
+  #         python3 -m pip install /tmp/*.whl
 
-      - name: Install oldest versions of dependencies
-        run: |
-          python3 -m pip install ${{ matrix.numpy_min_version }} ${{ matrix.opencv_min_version }}
+  #     - name: Install oldest versions of dependencies
+  #       run: |
+  #         python3 -m pip install ${{ matrix.numpy_min_version }} ${{ matrix.opencv_min_version }}
 
-      - name: Run unit tests
-        run: |
-          python3 -m unittest discover -s tests -p "*tests.py"
+  #     - name: Run unit tests
+  #       run: |
+  #         python3 -m unittest discover -s tests -p "*tests.py"
   
   push_docker:
     name: Push Docker image to DockerHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
   test_docker:
     name: Run unit tests in Docker container (only for the Python version used in the Dockerfile command)
     runs-on: ubuntu-latest
-    needs: build_docker
+    needs:
+      - build_docker
 
     steps:
       - name: Checkout
@@ -140,6 +141,61 @@ jobs:
         with:
           name: python-wheel-${{ matrix.python }}
           path: ./wheelhouse/*.whl
+
+  test_wheel_against_oldest_dependencies:
+    name: Test wheels against oldest supported versions of dependencies
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.image }}
+    needs:
+      - build_docker
+      - build_and_test_wheels
+    strategy:
+      # Ensure that a wheel builder finishes even if another fails
+      fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+          image: python:3.9
+          numpy_min_version: "numpy==1.19.3"
+          opencv_min_version: "opencv==4.4.0.46"
+        - os: ubuntu-latest
+          image: python:3.9
+          numpy_min_version: "numpy==1.21.2"
+          opencv_min_version: "opencv==4.5.4.60"
+        # - os: ubuntu-latest
+        #   python: "3.11"
+        #   numpy_min_version: 
+        #   opencv_min_version: 
+        # - os: ubuntu-latest
+        #   python: "3.12"
+        #   numpy_min_version: 
+        #   opencv_min_version: 
+        # - os: ubuntu-latest
+        #   python: "3.13"
+        #   numpy_min_version: 
+        #   opencv_min_version: 
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheel-${{ matrix.python }}
+          path: /tmp
+
+      - name: Install wheel
+        run: |
+          python3 -m pip install /tmp/*.whl
+
+      - name: Install oldest versions of dependencies
+        run: |
+          python3 -m pip install ${{ matrix.numpy_min_version }} ${{ matrix.opencv_min_version }}
+
+      - name: Run unit tests
+        run: |
+          python3 -m unittest discover -s tests -p "*tests.py"
   
   push_docker:
     name: Push Docker image to DockerHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,29 +89,36 @@ jobs:
           platform_id: manylinux_x86_64
           manylinux_image: mv-extractor:local
           numpy_min_version: "numpy==1.19.3"
-          opencv_min_version: "opencv==4.4.0.46"
+          opencv_min_version: "opencv-python==4.4.0.46"
         - os: ubuntu-latest
           python: 310
           bitness: 64
           platform_id: manylinux_x86_64
           manylinux_image: mv-extractor:local
           numpy_min_version: "numpy==1.21.2"
-          opencv_min_version: "opencv==4.5.4.60"
-        # - os: ubuntu-latest
-        #   python: 311
-        #   bitness: 64
-        #   platform_id: manylinux_x86_64
-        #   manylinux_image: mv-extractor:local
-        # - os: ubuntu-latest
-        #   python: 312
-        #   bitness: 64
-        #   platform_id: manylinux_x86_64
-        #   manylinux_image: mv-extractor:local
+          opencv_min_version: "opencv-python==4.5.4.60"
+        - os: ubuntu-latest
+          python: 311
+          bitness: 64
+          platform_id: manylinux_x86_64
+          manylinux_image: mv-extractor:local
+          numpy_min_version: "numpy==1.23.3"
+          opencv_min_version: "opencv-python==4.7.0.72"
+        - os: ubuntu-latest
+          python: 312
+          bitness: 64
+          platform_id: manylinux_x86_64
+          manylinux_image: mv-extractor:local
+          numpy_min_version: "numpy==1.26.0"
+          opencv_min_version: "opencv-python==4.9.0.80"
+        # opencv-python does not yet support Python 3.13 as of Oct 2024
         # - os: ubuntu-latest
         #   python: 313
         #   bitness: 64
         #   platform_id: manylinux_x86_64
         #   manylinux_image: mv-extractor:local
+        #   numpy_min_version: "numpy==2.1.0"
+        #   opencv_min_version: "opencv-python=="
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=61.0",
     "pkgconfig>=1.5.1",
-    "numpy>=1.17.0,<2"
+    "numpy>=2.0.0"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -66,5 +66,5 @@ setup(
     python_requires='>=3.9, <4',
     # minimum versions of numpy and opencv are the oldest versions
     # just supporting the minimum Python version (Python 3.9)
-    install_requires=['numpy>=1.19.3', 'opencv-python>=4.4.0.46,<4.11']
+    install_requires=['numpy>=1.19.3', 'opencv-python>=4.4.0.46']
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ mvextractor = Extension('mvextractor.videocap',
     extra_compile_args = ['-std=c++11'],
     extra_link_args = ['-fPIC', '-Wl,-Bsymbolic'])
 
-setup(name='motion-vector-extractor',
+setup(
+    name='motion-vector-extractor',
     author='Lukas Bommes',
     author_email=' ',
     version="1.0.7",
@@ -63,4 +64,7 @@ setup(name='motion-vector-extractor',
             ],
     },
     python_requires='>=3.9, <4',
-    install_requires=['numpy>=1.17.0,<2', 'opencv-python>=4.1.0.25,<4.11'])
+    # minimum versions of numpy and opencv are the oldest versions
+    # just supporting the minimum Python version (Python 3.9)
+    install_requires=['numpy>=1.19.3', 'opencv-python>=4.4.0.46,<4.11']
+)


### PR DESCRIPTION
Numpy 2.0.0 broke ABI-compatibility with numpy 1.x releases. To support both numpy 1.x and numpy 2.x as runtime dependencies, numpy 2 has to be used during build time.

In addition to updating the build time dependency, this PR also bumpy the oldest supported versions for numpy (and opencv) to those versions that just introduced support for Python 3.9. The PR also removes the upper cap on the opencv version following the best practice explained [here](https://iscinumpy.dev/post/bound-version-constraints/).

A CI job is added which run unit tests against the oldest supported versions of Python, numpy and opencv.

Closes https://github.com/LukasBommes/mv-extractor/issues/52 and https://github.com/LukasBommes/mv-extractor/issues/57